### PR TITLE
feat: add menu page for multiple apps

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,0 +1,16 @@
+# AGENTS
+
+## Scope
+These instructions apply to the entire repository.
+
+## Testing
+- Run `npm test` (currently no tests, but execute the command).
+- Run `npm run lint` before committing.
+
+## Development Notes
+- The home page (`src/app/page.tsx`) presents links to ten apps.
+- Each app page (`src/app/appN/page.tsx`) must:
+  - Export `metadata` with a Japanese title.
+  - Wrap content in a `<main>` element.
+  - Provide a link back to the home menu (`/`).
+  - Use Japanese text for UI labels.

--- a/src/app/app1/page.tsx
+++ b/src/app/app1/page.tsx
@@ -1,0 +1,191 @@
+'use client';
+
+import Link from 'next/link';
+import { useState } from 'react';
+import type { Metadata } from 'next';
+
+export const metadata: Metadata = {
+  title: 'ToDoリスト',
+};
+
+interface TodoItem {
+  id: number;
+  text: string;
+  completed: boolean;
+}
+
+export default function TodoApp() {
+  const [todos, setTodos] = useState<TodoItem[]>([]);
+  const [doneItems, setDoneItems] = useState<TodoItem[]>([]);
+  const [inputValue, setInputValue] = useState('');
+  const [searchQuery, setSearchQuery] = useState('');
+
+  const addTodo = () => {
+    if (inputValue.trim() !== '') {
+      const newTodo: TodoItem = {
+        id: Date.now(),
+        text: inputValue.trim(),
+        completed: false
+      };
+      setTodos([...todos, newTodo]);
+      setInputValue('');
+    }
+  };
+
+  const deleteTodo = (id: number) => {
+    setTodos(todos.filter(todo => todo.id !== id));
+  };
+
+  const completeTodo = (id: number) => {
+    const todoToComplete = todos.find(todo => todo.id === id);
+    if (todoToComplete) {
+      setTodos(todos.filter(todo => todo.id !== id));
+      setDoneItems([...doneItems, { ...todoToComplete, completed: true }]);
+    }
+  };
+
+  const deleteDoneItem = (id: number) => {
+    setDoneItems(doneItems.filter(item => item.id !== id));
+  };
+
+  const incompleteTodo = (id: number) => {
+    const doneItemToIncomplete = doneItems.find(item => item.id === id);
+    if (doneItemToIncomplete) {
+      setDoneItems(doneItems.filter(item => item.id !== id));
+      setTodos([...todos, { ...doneItemToIncomplete, completed: false }]);
+    }
+  };
+
+  const handleKeyPress = (e: React.KeyboardEvent) => {
+    if (e.key === 'Enter') {
+      addTodo();
+    }
+  };
+
+  // Filter todos and done items based on search query
+  const filteredTodos = todos.filter(todo =>
+    todo.text.toLowerCase().includes(searchQuery.toLowerCase())
+  );
+  
+  const filteredDoneItems = doneItems.filter(item =>
+    item.text.toLowerCase().includes(searchQuery.toLowerCase())
+  );
+
+  return (
+    <main className="min-h-screen bg-background p-4 sm:p-8">
+      <div className="max-w-2xl mx-auto">
+        <Link href="/" className="text-blue-500 underline block mb-4">
+          ホームに戻る
+        </Link>
+        <h1 className="text-3xl font-bold text-center mb-8 text-foreground">
+          ToDoリスト
+        </h1>
+        
+        {/* Search Filter */}
+        <div className="mb-6">
+          <input
+            type="text"
+            value={searchQuery}
+            onChange={(e) => setSearchQuery(e.target.value)}
+            placeholder="タイトルで検索..."
+            className="w-full px-4 py-2 border border-gray-300 rounded-lg focus:outline-none focus:ring-2 focus:ring-blue-500 dark:bg-gray-700 dark:border-gray-600 dark:text-white"
+          />
+        </div>
+        
+        {/* Add Todo Form */}
+        <div className="mb-8">
+          <div className="flex gap-2">
+            <input
+              type="text"
+              value={inputValue}
+              onChange={(e) => setInputValue(e.target.value)}
+              onKeyPress={handleKeyPress}
+              placeholder="新しいタスクを入力..."
+              className="flex-1 px-4 py-2 border border-gray-300 rounded-lg focus:outline-none focus:ring-2 focus:ring-blue-500 dark:bg-gray-700 dark:border-gray-600 dark:text-white"
+            />
+            <button
+              onClick={addTodo}
+              className="px-6 py-2 bg-blue-500 text-white rounded-lg hover:bg-blue-600 focus:outline-none focus:ring-2 focus:ring-blue-500 transition-colors"
+            >
+              追加
+            </button>
+          </div>
+        </div>
+
+        {/* ToDo List */}
+        <div className="mb-8">
+          <h2 className="text-xl font-semibold mb-4 text-foreground">
+            ToDo ({filteredTodos.length})
+          </h2>
+          {filteredTodos.length === 0 ? (
+            <p className="text-gray-500 text-center py-8">
+              {searchQuery ? '検索結果がありません' : 'リストは空です'}
+            </p>
+          ) : (
+            <div className="space-y-2">
+              {filteredTodos.map((todo) => (
+                <div
+                  key={todo.id}
+                  className="flex items-center gap-3 p-3 bg-white dark:bg-gray-800 rounded-lg shadow-sm border border-gray-200 dark:border-gray-700"
+                >
+                  <button
+                    onClick={() => completeTodo(todo.id)}
+                    className="flex-shrink-0 w-6 h-6 border-2 border-gray-300 rounded-full hover:border-green-500 focus:outline-none focus:ring-2 focus:ring-green-500 transition-colors"
+                    title="完了"
+                  >
+                    <span className="sr-only">完了</span>
+                  </button>
+                  <span className="flex-1 text-foreground">{todo.text}</span>
+                  <button
+                    onClick={() => deleteTodo(todo.id)}
+                    className="flex-shrink-0 px-3 py-1 bg-red-500 text-white rounded hover:bg-red-600 focus:outline-none focus:ring-2 focus:ring-red-500 transition-colors text-sm"
+                  >
+                    削除
+                  </button>
+                </div>
+              ))}
+            </div>
+          )}
+        </div>
+
+        {/* DONE List */}
+        <div>
+          <h2 className="text-xl font-semibold mb-4 text-foreground">
+            DONE ({filteredDoneItems.length})
+          </h2>
+          {filteredDoneItems.length === 0 ? (
+            <p className="text-gray-500 text-center py-8">
+              {searchQuery ? '検索結果がありません' : '完了したタスクはありません'}
+            </p>
+          ) : (
+            <div className="space-y-2">
+              {filteredDoneItems.map((item) => (
+                <div
+                  key={item.id}
+                  className="flex items-center gap-3 p-3 bg-green-50 dark:bg-green-900/20 rounded-lg shadow-sm border border-green-200 dark:border-green-700"
+                >
+                  <div className="flex-shrink-0 w-6 h-6 bg-green-500 rounded-full flex items-center justify-center">
+                    <span className="text-white text-sm">✓</span>
+                  </div>
+                  <span className="flex-1 text-foreground line-through opacity-75">{item.text}</span>
+                  <button
+                    onClick={() => incompleteTodo(item.id)}
+                    className="flex-shrink-0 px-3 py-1 bg-blue-500 text-white rounded hover:bg-blue-600 focus:outline-none focus:ring-2 focus:ring-blue-500 transition-colors text-sm"
+                  >
+                    未完了に戻す
+                  </button>
+                  <button
+                    onClick={() => deleteDoneItem(item.id)}
+                    className="flex-shrink-0 px-3 py-1 bg-red-500 text-white rounded hover:bg-red-600 focus:outline-none focus:ring-2 focus:ring-red-500 transition-colors text-sm"
+                  >
+                    削除
+                  </button>
+                </div>
+              ))}
+            </div>
+          )}
+        </div>
+      </div>
+    </main>
+  );
+}

--- a/src/app/app10/page.tsx
+++ b/src/app/app10/page.tsx
@@ -1,0 +1,18 @@
+import Link from 'next/link';
+import type { Metadata } from 'next';
+
+export const metadata: Metadata = {
+  title: 'アプリ10',
+};
+
+export default function App10() {
+  return (
+    <main className="min-h-screen p-8 bg-background text-foreground">
+      <h1 className="text-2xl font-bold mb-4">アプリ10</h1>
+      <p>このアプリは準備中です。</p>
+      <Link href="/" className="text-blue-500 underline block mt-4">
+        ホームに戻る
+      </Link>
+    </main>
+  );
+}

--- a/src/app/app2/page.tsx
+++ b/src/app/app2/page.tsx
@@ -1,0 +1,18 @@
+import Link from 'next/link';
+import type { Metadata } from 'next';
+
+export const metadata: Metadata = {
+  title: 'アプリ2',
+};
+
+export default function App2() {
+  return (
+    <main className="min-h-screen p-8 bg-background text-foreground">
+      <h1 className="text-2xl font-bold mb-4">アプリ2</h1>
+      <p>このアプリは準備中です。</p>
+      <Link href="/" className="text-blue-500 underline block mt-4">
+        ホームに戻る
+      </Link>
+    </main>
+  );
+}

--- a/src/app/app3/page.tsx
+++ b/src/app/app3/page.tsx
@@ -1,0 +1,18 @@
+import Link from 'next/link';
+import type { Metadata } from 'next';
+
+export const metadata: Metadata = {
+  title: 'アプリ3',
+};
+
+export default function App3() {
+  return (
+    <main className="min-h-screen p-8 bg-background text-foreground">
+      <h1 className="text-2xl font-bold mb-4">アプリ3</h1>
+      <p>このアプリは準備中です。</p>
+      <Link href="/" className="text-blue-500 underline block mt-4">
+        ホームに戻る
+      </Link>
+    </main>
+  );
+}

--- a/src/app/app4/page.tsx
+++ b/src/app/app4/page.tsx
@@ -1,0 +1,18 @@
+import Link from 'next/link';
+import type { Metadata } from 'next';
+
+export const metadata: Metadata = {
+  title: 'アプリ4',
+};
+
+export default function App4() {
+  return (
+    <main className="min-h-screen p-8 bg-background text-foreground">
+      <h1 className="text-2xl font-bold mb-4">アプリ4</h1>
+      <p>このアプリは準備中です。</p>
+      <Link href="/" className="text-blue-500 underline block mt-4">
+        ホームに戻る
+      </Link>
+    </main>
+  );
+}

--- a/src/app/app5/page.tsx
+++ b/src/app/app5/page.tsx
@@ -1,0 +1,18 @@
+import Link from 'next/link';
+import type { Metadata } from 'next';
+
+export const metadata: Metadata = {
+  title: 'アプリ5',
+};
+
+export default function App5() {
+  return (
+    <main className="min-h-screen p-8 bg-background text-foreground">
+      <h1 className="text-2xl font-bold mb-4">アプリ5</h1>
+      <p>このアプリは準備中です。</p>
+      <Link href="/" className="text-blue-500 underline block mt-4">
+        ホームに戻る
+      </Link>
+    </main>
+  );
+}

--- a/src/app/app6/page.tsx
+++ b/src/app/app6/page.tsx
@@ -1,0 +1,18 @@
+import Link from 'next/link';
+import type { Metadata } from 'next';
+
+export const metadata: Metadata = {
+  title: 'アプリ6',
+};
+
+export default function App6() {
+  return (
+    <main className="min-h-screen p-8 bg-background text-foreground">
+      <h1 className="text-2xl font-bold mb-4">アプリ6</h1>
+      <p>このアプリは準備中です。</p>
+      <Link href="/" className="text-blue-500 underline block mt-4">
+        ホームに戻る
+      </Link>
+    </main>
+  );
+}

--- a/src/app/app7/page.tsx
+++ b/src/app/app7/page.tsx
@@ -1,0 +1,18 @@
+import Link from 'next/link';
+import type { Metadata } from 'next';
+
+export const metadata: Metadata = {
+  title: 'アプリ7',
+};
+
+export default function App7() {
+  return (
+    <main className="min-h-screen p-8 bg-background text-foreground">
+      <h1 className="text-2xl font-bold mb-4">アプリ7</h1>
+      <p>このアプリは準備中です。</p>
+      <Link href="/" className="text-blue-500 underline block mt-4">
+        ホームに戻る
+      </Link>
+    </main>
+  );
+}

--- a/src/app/app8/page.tsx
+++ b/src/app/app8/page.tsx
@@ -1,0 +1,18 @@
+import Link from 'next/link';
+import type { Metadata } from 'next';
+
+export const metadata: Metadata = {
+  title: 'アプリ8',
+};
+
+export default function App8() {
+  return (
+    <main className="min-h-screen p-8 bg-background text-foreground">
+      <h1 className="text-2xl font-bold mb-4">アプリ8</h1>
+      <p>このアプリは準備中です。</p>
+      <Link href="/" className="text-blue-500 underline block mt-4">
+        ホームに戻る
+      </Link>
+    </main>
+  );
+}

--- a/src/app/app9/page.tsx
+++ b/src/app/app9/page.tsx
@@ -1,0 +1,18 @@
+import Link from 'next/link';
+import type { Metadata } from 'next';
+
+export const metadata: Metadata = {
+  title: 'アプリ9',
+};
+
+export default function App9() {
+  return (
+    <main className="min-h-screen p-8 bg-background text-foreground">
+      <h1 className="text-2xl font-bold mb-4">アプリ9</h1>
+      <p>このアプリは準備中です。</p>
+      <Link href="/" className="text-blue-500 underline block mt-4">
+        ホームに戻る
+      </Link>
+    </main>
+  );
+}

--- a/src/app/layout.tsx
+++ b/src/app/layout.tsx
@@ -2,8 +2,8 @@ import type { Metadata } from "next";
 import "./globals.css";
 
 export const metadata: Metadata = {
-  title: "TODO リスト - Test Pages",
-  description: "シンプルなTODOリストアプリケーション",
+  title: "Test Pages",
+  description: "アプリケーションメニュー",
 };
 
 export default function RootLayout({

--- a/src/app/page.tsx
+++ b/src/app/page.tsx
@@ -1,182 +1,25 @@
-'use client';
+import Link from 'next/link';
+import type { Metadata } from 'next';
 
-import { useState } from 'react';
+export const metadata: Metadata = {
+  title: 'アプリメニュー',
+};
 
-interface TodoItem {
-  id: number;
-  text: string;
-  completed: boolean;
-}
-
-export default function TodoApp() {
-  const [todos, setTodos] = useState<TodoItem[]>([]);
-  const [doneItems, setDoneItems] = useState<TodoItem[]>([]);
-  const [inputValue, setInputValue] = useState('');
-  const [searchQuery, setSearchQuery] = useState('');
-
-  const addTodo = () => {
-    if (inputValue.trim() !== '') {
-      const newTodo: TodoItem = {
-        id: Date.now(),
-        text: inputValue.trim(),
-        completed: false
-      };
-      setTodos([...todos, newTodo]);
-      setInputValue('');
-    }
-  };
-
-  const deleteTodo = (id: number) => {
-    setTodos(todos.filter(todo => todo.id !== id));
-  };
-
-  const completeTodo = (id: number) => {
-    const todoToComplete = todos.find(todo => todo.id === id);
-    if (todoToComplete) {
-      setTodos(todos.filter(todo => todo.id !== id));
-      setDoneItems([...doneItems, { ...todoToComplete, completed: true }]);
-    }
-  };
-
-  const deleteDoneItem = (id: number) => {
-    setDoneItems(doneItems.filter(item => item.id !== id));
-  };
-
-  const incompleteTodo = (id: number) => {
-    const doneItemToIncomplete = doneItems.find(item => item.id === id);
-    if (doneItemToIncomplete) {
-      setDoneItems(doneItems.filter(item => item.id !== id));
-      setTodos([...todos, { ...doneItemToIncomplete, completed: false }]);
-    }
-  };
-
-  const handleKeyPress = (e: React.KeyboardEvent) => {
-    if (e.key === 'Enter') {
-      addTodo();
-    }
-  };
-
-  // Filter todos and done items based on search query
-  const filteredTodos = todos.filter(todo =>
-    todo.text.toLowerCase().includes(searchQuery.toLowerCase())
-  );
-  
-  const filteredDoneItems = doneItems.filter(item =>
-    item.text.toLowerCase().includes(searchQuery.toLowerCase())
-  );
-
+export default function MenuPage() {
   return (
-    <div className="min-h-screen bg-background p-4 sm:p-8">
-      <div className="max-w-2xl mx-auto">
-        <h1 className="text-3xl font-bold text-center mb-8 text-foreground">
-          TODO リスト
-        </h1>
-        
-        {/* Search Filter */}
-        <div className="mb-6">
-          <input
-            type="text"
-            value={searchQuery}
-            onChange={(e) => setSearchQuery(e.target.value)}
-            placeholder="タイトルで検索..."
-            className="w-full px-4 py-2 border border-gray-300 rounded-lg focus:outline-none focus:ring-2 focus:ring-blue-500 dark:bg-gray-700 dark:border-gray-600 dark:text-white"
-          />
-        </div>
-        
-        {/* Add Todo Form */}
-        <div className="mb-8">
-          <div className="flex gap-2">
-            <input
-              type="text"
-              value={inputValue}
-              onChange={(e) => setInputValue(e.target.value)}
-              onKeyPress={handleKeyPress}
-              placeholder="新しいタスクを入力..."
-              className="flex-1 px-4 py-2 border border-gray-300 rounded-lg focus:outline-none focus:ring-2 focus:ring-blue-500 dark:bg-gray-700 dark:border-gray-600 dark:text-white"
-            />
-            <button
-              onClick={addTodo}
-              className="px-6 py-2 bg-blue-500 text-white rounded-lg hover:bg-blue-600 focus:outline-none focus:ring-2 focus:ring-blue-500 transition-colors"
-            >
-              追加
-            </button>
-          </div>
-        </div>
-
-        {/* TODO List */}
-        <div className="mb-8">
-          <h2 className="text-xl font-semibold mb-4 text-foreground">
-            TODO ({filteredTodos.length})
-          </h2>
-          {filteredTodos.length === 0 ? (
-            <p className="text-gray-500 text-center py-8">
-              {searchQuery ? '検索結果がありません' : 'リストは空です'}
-            </p>
-          ) : (
-            <div className="space-y-2">
-              {filteredTodos.map((todo) => (
-                <div
-                  key={todo.id}
-                  className="flex items-center gap-3 p-3 bg-white dark:bg-gray-800 rounded-lg shadow-sm border border-gray-200 dark:border-gray-700"
-                >
-                  <button
-                    onClick={() => completeTodo(todo.id)}
-                    className="flex-shrink-0 w-6 h-6 border-2 border-gray-300 rounded-full hover:border-green-500 focus:outline-none focus:ring-2 focus:ring-green-500 transition-colors"
-                    title="完了"
-                  >
-                    <span className="sr-only">完了</span>
-                  </button>
-                  <span className="flex-1 text-foreground">{todo.text}</span>
-                  <button
-                    onClick={() => deleteTodo(todo.id)}
-                    className="flex-shrink-0 px-3 py-1 bg-red-500 text-white rounded hover:bg-red-600 focus:outline-none focus:ring-2 focus:ring-red-500 transition-colors text-sm"
-                  >
-                    削除
-                  </button>
-                </div>
-              ))}
-            </div>
-          )}
-        </div>
-
-        {/* DONE List */}
-        <div>
-          <h2 className="text-xl font-semibold mb-4 text-foreground">
-            DONE ({filteredDoneItems.length})
-          </h2>
-          {filteredDoneItems.length === 0 ? (
-            <p className="text-gray-500 text-center py-8">
-              {searchQuery ? '検索結果がありません' : '完了したタスクはありません'}
-            </p>
-          ) : (
-            <div className="space-y-2">
-              {filteredDoneItems.map((item) => (
-                <div
-                  key={item.id}
-                  className="flex items-center gap-3 p-3 bg-green-50 dark:bg-green-900/20 rounded-lg shadow-sm border border-green-200 dark:border-green-700"
-                >
-                  <div className="flex-shrink-0 w-6 h-6 bg-green-500 rounded-full flex items-center justify-center">
-                    <span className="text-white text-sm">✓</span>
-                  </div>
-                  <span className="flex-1 text-foreground line-through opacity-75">{item.text}</span>
-                  <button
-                    onClick={() => incompleteTodo(item.id)}
-                    className="flex-shrink-0 px-3 py-1 bg-blue-500 text-white rounded hover:bg-blue-600 focus:outline-none focus:ring-2 focus:ring-blue-500 transition-colors text-sm"
-                  >
-                    未完了に戻す
-                  </button>
-                  <button
-                    onClick={() => deleteDoneItem(item.id)}
-                    className="flex-shrink-0 px-3 py-1 bg-red-500 text-white rounded hover:bg-red-600 focus:outline-none focus:ring-2 focus:ring-red-500 transition-colors text-sm"
-                  >
-                    削除
-                  </button>
-                </div>
-              ))}
-            </div>
-          )}
-        </div>
-      </div>
-    </div>
+    <main className="min-h-screen p-8 bg-background text-foreground">
+      <h1 className="text-3xl font-bold mb-8 text-center">アプリメニュー</h1>
+      <ul className="space-y-4 max-w-md mx-auto">
+        {['ToDoリスト', ...Array.from({ length: 9 }, (_, i) => `アプリ${i + 2}`)].map(
+          (name, i) => (
+            <li key={i} className="p-4 bg-white dark:bg-gray-800 rounded shadow">
+              <Link href={`/app${i + 1}`} className="block text-center">
+                {name}
+              </Link>
+            </li>
+          )
+        )}
+      </ul>
+    </main>
   );
 }


### PR DESCRIPTION
## Summary
- add home screen with links for 10 apps and metadata
- add back-to-home links and per-app metadata
- document project guidelines in AGENTS.md
- label first menu item and app metadata as "ToDoリスト"

## Testing
- `npm test` *(fails: command not found: npm; attempted `apt-get update` but repository not signed)*
- `npm run lint` *(fails: command not found: npm)*

------
https://chatgpt.com/codex/tasks/task_e_68c01c83d9148328a0a47b0391a5aae4